### PR TITLE
Add scripts for setup and develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "postinstall": "husky",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable",
-    "test": "instant-mocha --webpack-config ./test/webpack.config.js --require ./test/setup.cjs \"test/**/*.ts\""
+    "test": "instant-mocha --webpack-config ./test/webpack.config.js --require ./test/setup.cjs \"test/**/*.ts\"",
+    "start": "script/develop",
+    "setup": "script/setup"
   },
   "author": "Paulus Schoutsen <Paulus@PaulusSchoutsen.nl> (http://paulusschoutsen.nl)",
   "license": "Apache-2.0",


### PR DESCRIPTION
Add yarn scripts for setup and develop

`yarn setup` will run "script/setup". Not really needed when not working in a dev container since then all it will do is run yarn install 
`yarn start` will run "script/develop"